### PR TITLE
Removed HttpGet attribute from child action methods which could need …

### DIFF
--- a/src/Admin/Controllers/FundMetadataController.cs
+++ b/src/Admin/Controllers/FundMetadataController.cs
@@ -16,7 +16,6 @@ namespace Admin.Controllers
         }
 
         [ChildActionOnly]
-        [HttpGet]
         public ActionResult _ListForFund(string id)
         {
             var model = Dependencies.ListViewModelBuilder.Build(new SearchCriteria() { FundCode = id });
@@ -25,7 +24,6 @@ namespace Admin.Controllers
         }
 
         [ChildActionOnly]
-        [HttpGet]
         public ActionResult _EditListForFund(string id)
         {
             var model = Dependencies.ListViewModelBuilder.Build(new SearchCriteria() { FundCode = id });

--- a/src/Admin/Controllers/ImportProcessingRuleActionController.cs
+++ b/src/Admin/Controllers/ImportProcessingRuleActionController.cs
@@ -16,7 +16,6 @@ namespace Admin.Controllers
         }
 
         [ChildActionOnly]
-        [HttpGet]
         public ActionResult _ListForImportProcessingRule(int id)
         {
             var model = Dependencies.ListViewModelBuilder.Build(new SearchCriteria() { ImportProcessingRuleId = id });
@@ -25,7 +24,6 @@ namespace Admin.Controllers
         }
 
         [ChildActionOnly]
-        [HttpGet]
         public ActionResult _EditListForImportProcessingRule(int id)
         {
             var model = Dependencies.ListViewModelBuilder.Build(new SearchCriteria() { ImportProcessingRuleId = id });

--- a/src/Admin/Controllers/ImportProcessingRuleConditionController.cs
+++ b/src/Admin/Controllers/ImportProcessingRuleConditionController.cs
@@ -16,7 +16,6 @@ namespace Admin.Controllers
         }
 
         [ChildActionOnly]
-        [HttpGet]
         public ActionResult _ListForImportProcessingRule(int id)
         {
             var model = Dependencies.ListViewModelBuilder.Build(new SearchCriteria() { ImportProcessingRuleId = id });
@@ -25,7 +24,6 @@ namespace Admin.Controllers
         }
 
         [ChildActionOnly]
-        [HttpGet]
         public ActionResult _EditListForImportProcessingRule(int id)
         {
             var model = Dependencies.ListViewModelBuilder.Build(new SearchCriteria() { ImportProcessingRuleId = id });

--- a/src/Admin/Controllers/MethodOfPaymentMetadataController.cs
+++ b/src/Admin/Controllers/MethodOfPaymentMetadataController.cs
@@ -16,7 +16,6 @@ namespace Admin.Controllers
         }
 
         [ChildActionOnly]
-        [HttpGet]
         public ActionResult _ListForMethodOfPayment(string id)
         {
             var model = Dependencies.ListViewModelBuilder.Build(new SearchCriteria() { MopCode = id });
@@ -25,7 +24,6 @@ namespace Admin.Controllers
         }
 
         [ChildActionOnly]
-        [HttpGet]
         public ActionResult _EditListForMethodOfPayment(string id)
         {
             var model = Dependencies.ListViewModelBuilder.Build(new SearchCriteria() { MopCode = id });

--- a/src/Admin/Controllers/VatMetadataController.cs
+++ b/src/Admin/Controllers/VatMetadataController.cs
@@ -16,7 +16,6 @@ namespace Admin.Controllers
         }
 
         [ChildActionOnly]
-        [HttpGet]
         public ActionResult _ListForVat(string id)
         {
             var model = Dependencies.ListViewModelBuilder.Build(new SearchCriteria() { VatCode = id });
@@ -25,7 +24,6 @@ namespace Admin.Controllers
         }
 
         [ChildActionOnly]
-        [HttpGet]
         public ActionResult _EditListForVat(string id)
         {
             var model = Dependencies.ListViewModelBuilder.Build(new SearchCriteria() { VatCode = id });


### PR DESCRIPTION
…calling as the result of a failed POST request (e.g. when model validation fails server side and we need to return to the page we posted from).