### PR TITLE
Ensure only transactions lines linked to refundable MOPs are shown in…

### DIFF
--- a/src/Admin/Classes/ViewModelBuilders/Transaction/DetailsViewModelBuilder.cs
+++ b/src/Admin/Classes/ViewModelBuilders/Transaction/DetailsViewModelBuilder.cs
@@ -32,7 +32,7 @@ namespace Admin.Classes.ViewModelBuilders.Transaction
 
             if (transaction.ProcessedRefunds != null)
             {
-                refund.RefundItems = transaction.TransactionLines
+                refund.RefundItems = transaction.RefundableTransactionLines
                     .Select(x => new RefundItem()
                     {
                         Transaction = x,

--- a/src/Admin/Classes/ViewModelBuilders/Transaction/RefundViewModelBuilder.cs
+++ b/src/Admin/Classes/ViewModelBuilders/Transaction/RefundViewModelBuilder.cs
@@ -32,7 +32,7 @@ namespace Admin.Classes.ViewModelBuilders.Transaction
 
             if (existingRefunds != null)
             {
-                foreach (var transactionLine in transaction.TransactionLines)
+                foreach (var transactionLine in transaction.RefundableTransactionLines)
                 {
                     var remainingAmount = transaction.AmountAvailableToTransferOrRefundForTransactionLine(transactionLine.TransactionReference);
 

--- a/src/BusinessLogic/Extensions/NumberFormatExtension.cs
+++ b/src/BusinessLogic/Extensions/NumberFormatExtension.cs
@@ -17,8 +17,8 @@
             string amount = value.ToString();
             if (value < 0)
             {
-                var nosigh = value * -1;
-                amount = nosigh + "-";
+                var nosign = value * -1;
+                amount = nosign + "-";
             }
             return amount;
         }

--- a/src/BusinessLogic/Services/PaymentService.cs
+++ b/src/BusinessLogic/Services/PaymentService.cs
@@ -395,7 +395,6 @@ namespace BusinessLogic.Services
 
                 return new PaymentResponse()
                 {
-                    // HIGH: Get the correct payment integration URL associated with the MOP Code relating to this transaction
                     ResponseId = result.PaymentId,
                     ResponseUrl = string.Format("{0}/{1}/{2}"
                         , paymentIntegration.BaseUri

--- a/src/BusinessLogic/Services/RefundService.cs
+++ b/src/BusinessLogic/Services/RefundService.cs
@@ -72,12 +72,12 @@ namespace BusinessLogic.Services
                     if (refundRequest.RefundAmount <= 0) continue;
 
                     var transaction = _transactionService.GetTransaction(refundRequest.TransactionReference);
-                    var transctionHeader = _transactionService.GetTransactionByPspReference(transaction.PspReference);
+                    var transactionHeader = _transactionService.GetTransactionByPspReference(transaction.PspReference);
                     internalReference = transaction.InternalReference;
                     transactionDate = transaction.TransactionDate ?? new DateTime();
                     mopCode = transaction.MopCode;
 
-                    var remainingAmount = transctionHeader.AmountAvailableToTransferOrRefundForTransactionLine(refundRequest.TransactionReference);
+                    var remainingAmount = transactionHeader.AmountAvailableToTransferOrRefundForTransactionLine(refundRequest.TransactionReference);
                     if (refundRequest.RefundAmount > remainingAmount)
                     {
                         return RefundStatus.ErrorStatus("Refund amount is greater than remaining transaction amount");
@@ -147,14 +147,15 @@ namespace BusinessLogic.Services
                     return RefundStatus.AcceptedStatus(totalRefundAmount);
                 }
 
-                // TODO: if we fail or have an exception we need to mark those as processed.
                 _transactionService.MarkRefundsAsFailed(internalReference, reason);
 
-                return RefundStatus.FailStatus(string.Empty); // HIGH: Sort this out - return refundResponse.response?
+                return RefundStatus.FailStatus(refundResponse.Message);
             }
             catch (Exception e)
             {
+                // TODO: What if an exception occurs before the the refund(s) (pending transaction(s)) have been created?
                 _transactionService.MarkRefundsAsFailed(internalReference, reason);
+
                 return RefundStatus.ErrorStatus(e.Message);
             }
         }


### PR DESCRIPTION
… the refund modal.

Fix the bug which is allowing the refund button to be enabled even though there are no funds remaining that can be refunded.